### PR TITLE
typos fixed in stochv 1_5 bedingte EW-Martingale

### DIFF
--- a/Math-Ba-STOCHV/STOCHV_Vorlesung/stochv_1_5_bedingterErwartungswertMartingale.tex
+++ b/Math-Ba-STOCHV/STOCHV_Vorlesung/stochv_1_5_bedingterErwartungswertMartingale.tex
@@ -104,7 +104,7 @@ Allgemeiner gilt:
 
 \subsection{Bedingte Erwartung: Maßtheoretischer Zugang}
 
-Wir betrachten den Wahrscheinlichkeitsraum $(\Omega, \F, \P)$. Für eine Zufallsvariable $\abb{X}{\Omega}{\R}$ und $p \in [1,\infty)$ definieren wir, doe $L_p$-Norm
+Wir betrachten den Wahrscheinlichkeitsraum $(\Omega, \F, \P)$. Für eine Zufallsvariable $\abb{X}{\Omega}{\R}$ und $p \in [1,\infty)$ definieren wir, die $L_p$-Norm
 \begin{equation*}
 \norm{X}_p \defeq \EW[\abs{X}^p]^{\frac{1}{p}} = \brackets{\int_\Omega \abs{X(\omega)}^p \diffskip{\P(\omega)}}^\frac{1}{p}
 \end{equation*}
@@ -123,7 +123,7 @@ Dabei identifizieren wir Zufallsvariablen, die sich nur auf $\P$-Nullmengen unte
 
 Für $\G \subseteq \F$ Unter-$\sigma$-Algebra ist $L_p(\Omega,\G,\P) \subseteq L_p(\Omega, \F, \P)$ ein abgeschlossener Unterraum.
 
-Wir verallgemeinern das ''Vorhersageproblem`` ais dem letzten Abschnitt: Gegeben sei ein Zufallsvariale $X$ aus $L_2(\Omega,\F,\P)$ und $\G \subseteq \F$ eine Unter-$\sigma$-Algebra. Was ist die beste $\G$-messbare Vorhersage für $X$?
+Wir verallgemeinern das ''Vorhersageproblem`` aus dem letzten Abschnitt: Gegeben sei ein Zufallsvariale $X$ aus $L_2(\Omega,\F,\P)$ und $\G \subseteq \F$ eine Unter-$\sigma$-Algebra. Was ist die beste $\G$-messbare Vorhersage für $X$?
 
 \begin{equation}
 \min\menge{\EW[(X-G)^2] : G \in L_2(\Omega,\G,\P)} \tag{min-2} \label{eq: min-2}
@@ -137,7 +137,7 @@ Wir bezeichnen $G_\ast$ mit $\EW[X|\G]$ als bedingten Erwartunswert von $X$ bez�
 
 \begin{theorem} %1.5 
 %	\label{theorem: 1.5}
-	SSeien $X,Y \in L_2(\Omega,\F,\P)$ und $\G \subseteq \F$ eine Unter-$\sigma$-Algebra. Dann gilt
+	Seien $X,Y \in L_2(\Omega,\F,\P)$ und $\G \subseteq \F$ eine Unter-$\sigma$-Algebra. Dann gilt
 	\begin{itemize}
 		\item Linearität: $\EW[aX + bY | \G] = a \EW[X|\G] + b\EW[Y|\G]$
 		\item Turmregel: Für jede weitere $\sigma$-Algebra $\mathcal{H} \subseteq \G$ gilt ${\EW[{\EW[{X|\G}]}|\mathcal{H}]} = {\EW[X|\mathcal{H}]}$


### PR DESCRIPTION
hab drei kleine tippfehler gefunden.